### PR TITLE
Add short delay between DMing votes.

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -125,6 +125,7 @@ class Admin(commands.Cog):
             max_react = list(helpers.EMOJI_LOOKUP)[num_candidates-1]
 
             for voter in helpers.registered_members:
+                await asyncio.sleep(0.5)
                 self.bot.loop.create_task(self.distribute_post_ballot(voter, post, num_candidates, max_react))
 
 


### PR DESCRIPTION
A problem, especially in the last AGM, is that the bot has been ratelimited while sending DMs to everyone. I believe this delay (0.5s) will fix this, as the ratelimit resets fairly often. I don't know exactly how long of a delay is needed.

Turnout is around 25/45 for E/AGM respectively, so this will only add 10-30s per role.